### PR TITLE
Add VDom parameter to Client, add as query parameter to request urls.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,79 @@
+package gofortiadc
+
+import (
+	"testing"
+)
+
+// TestClient_NewRequest creates an http.Request with authorization header set
+func TestClient_NewRequest(t *testing.T) {
+
+	// Create Table test case
+	type testCase struct {
+		method string
+		url    string
+		host   string
+		path   string
+		vdom   string
+	}
+
+	// Create test cases
+	testCases := []testCase{
+		{
+			method: "GET",
+			url:    "http://localhost:8080/api/v1/status/system",
+			host:   "localhost:8080",
+			path:   "/api/v1/status/system",
+			vdom:   "",
+		},
+		{
+			method: "POST",
+			url:    "http://localhost:8080/api/v1/status/system",
+			host:   "localhost:8080",
+			path:   "/api/v1/status/system",
+			vdom:   "root",
+		},
+	}
+	// Iterate over test cases
+	for _, tc := range testCases {
+
+		// Create client
+		client, err := NewClientHelper()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Set vdom parameter on client
+		client.VDom = tc.vdom
+
+		// Create request
+		req, err := client.NewRequest(tc.method, tc.url, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Test if req.Host is set with the correct value
+		if req.Host != tc.host {
+			t.Errorf("req.Host is not set with the correct value")
+		}
+
+		// Test if req.Path is set with the correct value
+		if req.URL.Path != tc.path {
+			t.Errorf("req.Path is not set with the correct value")
+		}
+
+		// Test if authorization header is set with the correct value
+		if req.Header.Get("Authorization") != "Bearer "+client.Token {
+			t.Errorf("Authorization header is not set")
+		}
+
+		// Test if vdom parameter is set when vdom is set on client
+		if tc.vdom != "" && req.URL.Query().Get("vdom") != tc.vdom {
+			t.Errorf("vdom parameter is not set")
+		}
+
+		// Test if vdom parameter is not set when vdom is not set on client
+		if tc.vdom == "" && req.URL.Query().Get("vdom") != "" {
+			t.Errorf("vdom parameter is set")
+		}
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -32,6 +32,13 @@ func TestClient_NewRequest(t *testing.T) {
 			path:   "/api/v1/status/system",
 			vdom:   "root",
 		},
+		{
+			method: "POST",
+			url:    "http://localhost:8080/api/load_balance_virtual_server?mkey=test",
+			host:   "localhost:8080",
+			path:   "/api/load_balance_virtual_server",
+			vdom:   "root",
+		},
 	}
 	// Iterate over test cases
 	for _, tc := range testCases {
@@ -53,12 +60,12 @@ func TestClient_NewRequest(t *testing.T) {
 
 		// Test if req.Host is set with the correct value
 		if req.Host != tc.host {
-			t.Errorf("req.Host is not set with the correct value")
+			t.Errorf("req.Host is not set with the correct value, expected %s, got %s", tc.host, req.Host)
 		}
 
 		// Test if req.Path is set with the correct value
 		if req.URL.Path != tc.path {
-			t.Errorf("req.Path is not set with the correct value")
+			t.Errorf("req.Path is not set with the correct value, expected: %s, got: %s", tc.path, req.URL.Path)
 		}
 
 		// Test if authorization header is set with the correct value


### PR DESCRIPTION
This adds support for the vdom query parameter on a per Client basis.


As found in the FortiADC docs:
![image](https://user-images.githubusercontent.com/108074780/175331537-64d2fd7e-e35b-4fb6-a6be-f9b4dc695bee.png)
https://s3.amazonaws.com/fortinetweb/docs.fortinet.com/v2/attachments/8bc35611-2436-11e9-b20a-f8bc1258b856/fortiadc-v5.1.x-restapi-deployment-guide.pdf