### PR TITLE
Add support for real server type "fqdn"

### DIFF
--- a/loadbalance_real_server.go
+++ b/loadbalance_real_server.go
@@ -10,7 +10,9 @@ import (
 
 // LoadbalanceRealServer represents a real server request/response
 type LoadbalanceRealServer struct {
+	Type     string `json:"type"`
 	Status   string `json:"status"`
+	FQDN     string `json:"FQDN"`
 	Address  string `json:"address"`
 	Address6 string `json:"address6"`
 	Mkey     string `json:"mkey"`

--- a/loadbalance_real_server_test.go
+++ b/loadbalance_real_server_test.go
@@ -99,3 +99,49 @@ func TestClient_Client_LoadbalanceDeleteRealServer(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestClient_LoadbalanceCreateRealServerFqdn(t *testing.T) {
+	if os.Getenv("TEST_LENS") != "true" {
+		t.Skip()
+	}
+
+	client, err := NewClientHelper()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := LoadbalanceRealServer{
+		Status: "enable",
+		Type:   "fqdn",
+		FQDN:   "test.example.com",
+		Mkey:   "gofortirs01",
+	}
+
+	err = client.LoadbalanceCreateRealServer(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_LoadbalanceUpdateRealServerFqdn(t *testing.T) {
+	if os.Getenv("TEST_LENS") != "true" {
+		t.Skip()
+	}
+
+	client, err := NewClientHelper()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := LoadbalanceRealServer{
+		Status: "enable",
+		Type:   "fqdn",
+		FQDN:   "test2.example.com",
+		Mkey:   "gofortirs01",
+	}
+
+	err = client.LoadbalanceUpdateRealServer(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
FortiADC version 5.4+ added support for the `type` parameter for loadbalance_real_servers
This type parameter supports two values "ip" and "fqdn"

 type="fqdn" will use the additional parameter `"FQDN"` to create a real server that can use a DNS name rather than an ip address. 
type="ip" remains the default and uses address and address6